### PR TITLE
Updated logging dependencies to get rid of CVE-2017-5929

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <sesame.version>2.7.16</sesame.version>
         <http.client.version>4.5.2</http.client.version>
         <jackson.version>2.8.5</jackson.version>
-        <slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
     </properties>
 
     <distributionManagement>
@@ -441,13 +441,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting ([CVE-2017-5929](http://www.cvedetails.com/cve/CVE-2017-5929/)) that should be fixed.